### PR TITLE
Updates for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 0.2.0-SNAPSHOT
+## Version 0.2.0
 
 * Improve conversion of `NDArray` to more data types
   * Add `DjlTools.getXXX()` methods to get ints, floats, doubles, longs and booleans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## Version 0.2.0-SNAPSHOT
+
+* Improve conversion of `NDArray` to more data types
+  * Add `DjlTools.getXXX()` methods to get ints, floats, doubles, longs and booleans
+* Estimate output size in `DjlDnnModel` if shape doesn't match NDLayout
+  * This relaxes the assumption that the output layout should match the input
+
+
+## Version 0.1.0
+
+* Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   * Add `DjlTools.getXXX()` methods to get ints, floats, doubles, longs and booleans
 * Estimate output size in `DjlDnnModel` if shape doesn't match NDLayout
   * This relaxes the assumption that the output layout should match the input
+* New `DjlTools.get/setOverrideDevice()` methods to override DJL's default device selection
+  * Primarily intended to explore `Device.fromName('mps')` on Apple Silicon (which sometimes works, sometimes doesn't...)
 
 
 ## Version 0.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,34 @@ plugins {
   id 'maven-publish'
   // To manage included native libraries
   alias(libs.plugins.javacpp)
+  // Need to use this instead (without version) if running as a QuPath subproject
+  // id 'org.bytedeco.gradle-javacpp-platform'
 }
 
 ext.moduleName = 'qupath.extension.djl'
 ext.qupathVersion = gradle.ext.qupathVersion
 
 description = 'QuPath extension to use Deep Java Library'
-version = "0.1.0"
+version = "0.2.0-SNAPSHOT"
 
 def djlVersion = libs.versions.deepJavaLibrary.get()
+
+repositories {
+	// Use this only for local development!
+//  mavenLocal()
+
+	mavenCentral()
+
+	maven {
+		url "https://maven.scijava.org/content/repositories/releases"
+	}
+
+	maven {
+		url "https://maven.scijava.org/content/repositories/snapshots"
+	}
+
+}
+
 
 dependencies {
     implementation "io.github.qupath:qupath-gui-fx:${qupathVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,14 @@ plugins {
   // To manage included native libraries
   alias(libs.plugins.javacpp)
   // Need to use this instead (without version) if running as a QuPath subproject
-  // id 'org.bytedeco.gradle-javacpp-platform'
+//  id 'org.bytedeco.gradle-javacpp-platform'
 }
 
 ext.moduleName = 'qupath.extension.djl'
 ext.qupathVersion = gradle.ext.qupathVersion
 
 description = 'QuPath extension to use Deep Java Library'
-version = "0.2.0-SNAPSHOT"
+version = "0.2.0"
 
 def djlVersion = libs.versions.deepJavaLibrary.get()
 

--- a/src/main/java/qupath/ext/djl/DjlDnnModel.java
+++ b/src/main/java/qupath/ext/djl/DjlDnnModel.java
@@ -207,7 +207,7 @@ class DjlDnnModel implements DnnModel<NDList>, AutoCloseable, UriResource {
 		@Override
 		public List<Mat> fromBlob(NDList blob) {
 			String layout;
-			if (ndLayout == null && !blob.isEmpty())
+			if ((ndLayout == null || ndLayout.length() != blob.singletonOrThrow().getShape().dimension()) && !blob.isEmpty())
 				layout = estimateOutputLayout(blob.get(0));
 			else
 				layout = ndLayout;

--- a/src/main/java/qupath/ext/djl/DjlTools.java
+++ b/src/main/java/qupath/ext/djl/DjlTools.java
@@ -373,9 +373,13 @@ public class DjlTools {
 			var buffer = mat.createBuffer();
 			array = manager.create(buffer, shape, dataType);			
 		} else {
+			var shapeDims = shape.getShape();
+			shapeDims[indC] = 1;
+			var shapeChannel = new Shape(shapeDims, shape.getLayout());
+
 			for (var mat2 : OpenCVTools.splitChannels(mat)) {
-				var buffer = mat2.createBuffer();				
-				var arrayTemp = manager.create(buffer, shape, dataType);
+				var buffer = mat2.createBuffer();
+				var arrayTemp = manager.create(buffer, shapeChannel, dataType);
 				if (array == null)
 					array = arrayTemp;
 				else {
@@ -469,25 +473,111 @@ public class DjlTools {
 			if (indexer instanceof ByteIndexer) {
 				((ByteIndexer) indexer).put(0L, array.toByteArray());
 			} else if (indexer instanceof UByteIndexer) {
-				((UByteIndexer) indexer).put(0L, array.toUint8Array());
+				((UByteIndexer) indexer).put(0L, getInts(array));
 			} else if (indexer instanceof UShortIndexer) {
-				((UShortIndexer) indexer).put(0L, array.toIntArray());
+				((UShortIndexer) indexer).put(0L, getInts(array));
 			} else if (indexer instanceof IntIndexer) {
-				((IntIndexer) indexer).put(0L, array.toIntArray());
+				((IntIndexer) indexer).put(0L, getInts(array));
 			} else if (indexer instanceof FloatIndexer) {
-				((FloatIndexer) indexer).put(0L, array.toFloatArray());
+				((FloatIndexer) indexer).put(0L, getFloats(array));
 			} else if (indexer instanceof HalfIndexer) {
-				((HalfIndexer) indexer).put(0L, array.toFloatArray());
+				((HalfIndexer) indexer).put(0L,getFloats(array));
 			} else if (indexer instanceof DoubleIndexer) {
-				((DoubleIndexer) indexer).put(0L, array.toDoubleArray());
+				((DoubleIndexer) indexer).put(0L, getDoubles(array));
 			} else if (indexer instanceof LongIndexer) {
-				((LongIndexer) indexer).put(0L, array.toLongArray());
+				((LongIndexer) indexer).put(0L, getLongs(array));
 			} else if (indexer instanceof BooleanIndexer) {
-				((BooleanIndexer) indexer).put(0L, array.toBooleanArray());
+				((BooleanIndexer) indexer).put(0L, getBooleans(array));
 			} else
 				throw new IllegalArgumentException("Unable to convert array " + array + " to Mat");
 		}
 		return mat;
+	}
+
+	/**
+	 * Extract array values as longs, converting if necessary.
+	 * @param array
+	 * @return
+	 */
+	public static long[] getLongs(NDArray array) {
+		if (array.getDataType() == DataType.INT64) {
+			try {
+				return array.toLongArray();
+			} catch (Exception e) {
+				logger.error("Exception requesting longs from NDArray");
+			}
+		}
+		return array.toType(DataType.INT64, true).toLongArray();
+	}
+
+	/**
+	 * Extract array values as booleans, converting if necessary.
+	 * @param array
+	 * @return
+	 */
+	private static boolean[] getBooleans(NDArray array) {
+		if (array.getDataType() == DataType.BOOLEAN) {
+			try {
+				return array.toBooleanArray();
+			} catch (Exception e) {
+				logger.error("Exception requesting ints from NDArray");
+			}
+		}
+		return array.toType(DataType.BOOLEAN, true).toBooleanArray();
+	}
+
+	/**
+	 * Extract array values as ints, converting if necessary.
+	 * @param array
+	 * @return
+	 */
+	private static int[] getInts(NDArray array) {
+		if (array.getDataType() == DataType.INT32) {
+			try {
+				return array.toIntArray();
+			} catch (Exception e) {
+				logger.error("Exception requesting ints from NDArray");
+			}
+		} else if (array.getDataType() == DataType.UINT8) {
+			try {
+				return array.toUint8Array();
+			} catch (Exception e) {
+				logger.error("Exception requesting ints from NDArray");
+			}
+		}
+		return array.toType(DataType.INT32, true).toIntArray();
+	}
+
+	/**
+	 * Extract array values as doubles, converting if necessary.
+	 * @param array
+	 * @return
+	 */
+	private static double[] getDoubles(NDArray array) {
+		if (array.getDataType() == DataType.FLOAT64) {
+			try {
+				return array.toDoubleArray();
+			} catch (Exception e) {
+				logger.error("Exception requesting doubles from NDArray");
+			}
+		}
+		return array.toType(DataType.FLOAT64, true).toDoubleArray();
+	}
+
+	/**
+	 * Extract array values as floats, converting if necessary.
+	 * @param array
+	 * @return
+	 */
+	private static float[] getFloats(NDArray array) {
+		if (array.getDataType() == DataType.FLOAT32 || array.getDataType() == DataType.FLOAT16) {
+			try {
+				return array.toFloatArray();
+			} catch (Exception e) {
+				logger.error("Exception requesting floats from NDArray", e);
+			}
+		}
+		return array.toType(DataType.FLOAT32, true).toFloatArray();
 	}
 	
 	


### PR DESCRIPTION
* Improve conversion of `NDArray` to more data types
  * Add `DjlTools.getXXX()` methods to get ints, floats, doubles, longs and booleans
* Estimate output size in `DjlDnnModel` if shape doesn't match NDLayout
  * This relaxes the assumption that the output layout should match the input
* New `DjlTools.get/setOverrideDevice()` methods to override DJL's default device selection
  * Primarily intended to explore `Device.fromName('mps')` on Apple Silicon (which sometimes works, sometimes doesn't...)