### PR TITLE
Switch to domain named prop and fix tensorflow toString issue

### DIFF
--- a/src/main/java/qupath/ext/djl/DjlExtension.java
+++ b/src/main/java/qupath/ext/djl/DjlExtension.java
@@ -43,7 +43,7 @@ public class DjlExtension implements QuPathExtension, GitHubProject {
 	
 	static {
 		// Prevent downloading engines automatically
-		System.setProperty("offline", "true");
+		System.setProperty("ai.djl.offline", "true");
 		// Opt out of tracking, see https://github.com/deepjavalibrary/djl/pull/2178/files
 		System.setProperty("OPT_OUT_TRACKING", "true");
 	}

--- a/src/main/java/qupath/ext/djl/DjlTools.java
+++ b/src/main/java/qupath/ext/djl/DjlTools.java
@@ -245,21 +245,20 @@ public class DjlTools {
 		}
 				
 		synchronized (lock) {
-			var offlineStatus = System.getProperty("offline");
+			var offlineStatus = System.getProperty("ai.djl.offline");
 			try {
 				if (downloadIfNeeded)
-					System.setProperty("offline", "false");
+					System.setProperty("ai.djl.offline", "false");
 				else
-					System.setProperty("offline", "true");
-				
+					System.setProperty("ai.djl.offline", "true");
 				var engine = Engine.getEngine(name);
 				if (engine != null)
 					loadedEngines.add(name);
 				return engine;
 			} catch (Exception e) {
-				if (downloadIfNeeded)
+				if (downloadIfNeeded) {
 					logger.error("Unable to get engine " + name + ": " + e.getMessage(), e);
-				else {
+				} else {
 					var msg = e.getLocalizedMessage();
 					if (msg == null)
 						logger.warn("Unable to get engine {}", name);
@@ -268,7 +267,7 @@ public class DjlTools {
 				}
 				return null;
 			} finally {
-				System.setProperty("offline", offlineStatus);
+				System.setProperty("ai.djl.offline", offlineStatus);
 			}
 		}
 	}

--- a/src/main/java/qupath/ext/djl/DjlZoo.java
+++ b/src/main/java/qupath/ext/djl/DjlZoo.java
@@ -244,10 +244,10 @@ public class DjlZoo {
 	 * @throws IOException
 	 */
 	public static Criteria<?, ?> buildCriteria(Artifact artifact, boolean allowDownload) throws ModelNotFoundException, MalformedModelException, IOException {
-		var before = System.getProperty("offline");
+		var before = System.getProperty("ai.djl.offline");
 		try {
 			if (allowDownload)
-				System.setProperty("offline", "false");
+				System.setProperty("ai.djl.offline", "false");
 			
 			
 			var application = artifact.getMetadata().getApplication();
@@ -300,7 +300,7 @@ public class DjlZoo {
 			}
 			return builder.build();
 		} finally {
-			System.setProperty("offline", before);
+			System.setProperty("ai.djl.offline", before);
 		}
 	}
 	

--- a/src/main/java/qupath/ext/djl/ui/DjlEngineCommand.java
+++ b/src/main/java/qupath/ext/djl/ui/DjlEngineCommand.java
@@ -268,7 +268,8 @@ public class DjlEngineCommand {
 			try {
 				var engine = Engine.getEngine(engineName);
 				labelVersion.setText(engine.getVersion());
-				labelVersion.setTooltip(new Tooltip(engine.toString()));
+				// this is toString, but TF ends up trying to download again.
+				labelVersion.setTooltip(new Tooltip(engine.getEngineName() + ':' + engine.getVersion()));
 				return;
 			} catch (Exception e) {
 				logger.error("Error updating engine version: {}", e.getMessage(), e);


### PR DESCRIPTION
Related to the PR linked in #18, this uses the domain named property, which is a bit less ambiguous.

Also fixes an error when trying to call toString on a TensorFlow engine, it'd end up going into `LibUtils.getLibName()` which leads eventually into `downloadTensorFlow`, which fails given the default offline setting

See https://github.com/deepjavalibrary/djl/blob/1d3613aaab1fcc5cbb3398a60152f6ce49a76342/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java#L177C62-L177C72