### PR TITLE
Update for Java 21, fix MPS bug

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ tasks.register("copyDependencies", Copy) {
  */
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(libs.versions.jdk.get())
     }
     if (project.properties['sources'])
 	    withSourcesJar()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/qupath/ext/djl/DjlExtension.java
+++ b/src/main/java/qupath/ext/djl/DjlExtension.java
@@ -83,7 +83,7 @@ public class DjlExtension implements QuPathExtension, GitHubProject {
 	
 	@Override
 	public Version getQuPathVersion() {
-		return Version.parse("0.5.0");
+		return Version.parse("0.6.0");
 	}
 	
 	

--- a/src/main/java/qupath/ext/djl/DjlTools.java
+++ b/src/main/java/qupath/ext/djl/DjlTools.java
@@ -598,8 +598,15 @@ public class DjlTools {
 			} catch (Exception e) {
 				logger.error("Exception requesting doubles from NDArray");
 			}
+		} else if (array.getDataType() == DataType.INT64) {
+			try {
+				return Arrays.stream(array.toLongArray()).mapToDouble(i -> i).toArray();
+			} catch (Exception e) {
+				logger.error("Exception requesting doubles from NDArray (from longs)");
+			}
 		}
-		return array.toType(DataType.FLOAT64, true).toDoubleArray();
+		// If the device is MPS, we can't convert to float64 - so make sure we're on the CPU
+		return array.toDevice(Device.cpu(), false).toType(DataType.FLOAT64, true).toDoubleArray();
 	}
 
 	/**


### PR DESCRIPTION
Update gradle and require Java 21, so we can use QuPath v0.6 dependencies. Also fix `DjlTools.getDoubles` to avoid converting to float64 on device, which was problematic on MPS.