### PR TITLE
Update gradle wrapper validation and publish command

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,11 +17,9 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
-    - name: Publish snapshot
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: publish -P release=true
+      uses: gradle/actions/wrapper-validation@v3
+    - name: Publish release
+      run: ./gradlew publish -P release=true
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -16,11 +16,9 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v3
     - name: Publish snapshot
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: publish
+      run: ./gradlew publish
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}


### PR DESCRIPTION
gradle wrapper validation action has moved. Also simplify the build call since we can just use ./gradlew publish