### PR TITLE
Ensure initialized before synchronized block

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,11 +30,9 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v3
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: build
+      run: ./gradlew build
     - uses: actions/upload-artifact@v4
       with:
         name: jar

--- a/src/main/java/qupath/ext/djl/DjlDnnModel.java
+++ b/src/main/java/qupath/ext/djl/DjlDnnModel.java
@@ -125,6 +125,7 @@ class DjlDnnModel implements DnnModel, AutoCloseable, UriResource {
 
 	@Override
 	public Map<String, Mat> predict(Map<String, Mat> blobs) {
+		ensureInitialized();
 		synchronized (predictor) {
 			try {
 				var result = predictor.predict(blobs.values().stream().toArray(Mat[]::new));


### PR DESCRIPTION
This resolves an error in the bioimageio extension if a user declines to open the output in imagej before loading the pixel classifier, and leads to an exception when trying to preview the output (although creating objects proceeds as normal).

I think it might be better to ensure initalization elsewhere but given this is a simple null check if the model is initialized, it should be fine to put here...